### PR TITLE
Add py.typed marker & update build config

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -74,6 +74,18 @@
         "focus": false,
         "panel": "shared"
       }
+    },
+    {
+      "label": "Format Pyproject",
+      "type": "shell",
+      "command": "uvx pyproject-fmt ${workspaceFolder}/pyproject.toml --indent 4",
+      "group": "build",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared"
+      }
     }
   ]
 }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.md
 include LICENCE.txt
 include pyproject.toml
+include src/py.typed
 recursive-include src *.py
 global-exclude __pycache__
 global-exclude *.py[cod]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ See the example resume definition [examples/resume.py](./examples/resume.py) and
 1. Install this package
 
    ```bash
-   pip install resume-builder
+   pip install git+https://github.com/koek67/resume-builder.git
+   ```
+
+   OR
+
+   ```bash
+   uv add https://github.com/koek67/resume-builder
    ```
 
 2. Proceed to [Usage section](#usage)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ See the example resume definition [examples/resume.py](./examples/resume.py) and
    OR
 
    ```bash
-   uv add https://github.com/koek67/resume-builder
+   uv add git+https://github.com/koek67/resume-builder
    ```
 
 2. Proceed to [Usage section](#usage)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,45 +2,46 @@
 build-backend = "hatchling.build"
 requires = ["hatchling"]
 
-[dependency-groups]
-dev = ["mypy>=1.4.1", "ruff>=0.12.1"]
-
 [project]
+name = "resume-builder"
+version = "0.1.0"
+
+description = "A no nonsense tool to build resumes in pure Python."
+readme = "README.md"
+keywords = ["builder", "cv", "generator", "html", "library", "resume"]
+license = "MIT"
+license-files = ["LICENCE.txt"]
 authors = [
     { email = "56448170+samuelhoover@users.noreply.github.com", name = "Samuel Hoover" },
     { email = "ask.mrdgh2821@outlook.com", name = "MRDGH2821" },
     { email = "krishnan.koushik@gmail.com", name = "koek67" },
 ]
+requires-python = ">=3.7"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup :: HTML",
     "Topic :: Utilities",
 ]
 dependencies = []
-description = "A no nonsense tool to build resumes in pure Python."
-keywords = ["builder", "cv", "generator", "html", "library", "resume"]
-license = "MIT"
-license-files = ["LICENCE.txt"]
-name = "resume-builder"
-readme = "README.md"
-requires-python = ">= 3.7"
-version = "0.1.0"
+urls.Documentation = "https://github.com/koek67/resume-builder#readme"
+urls.Homepage = "https://github.com/koek67/resume-builder"
+urls.Issues = "https://github.com/koek67/resume-builder/issues"
+urls.Repository = "https://github.com/koek67/resume-builder"
 
-[project.urls]
-Documentation = "https://github.com/koek67/resume-builder#readme"
-Homepage = "https://github.com/koek67/resume-builder"
-Issues = "https://github.com/koek67/resume-builder/issues"
-Repository = "https://github.com/koek67/resume-builder"
+[dependency-groups]
+dev = ["mypy>=1.4.1", "ruff>=0.12.1"]
+
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
@@ -48,12 +49,8 @@ packages = ["src"]
 [tool.hatch.build.targets.wheel.sources]
 src = "resume_builder"
 
-[tool.ruff.format]
-line-ending = "lf"
-
-[tool.ruff.lint]
-fixable = ["ALL"]
-select = ["ALL"]
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+[tool.ruff]
+format.line-ending = "lf"
+lint.select = ["ALL"]
+lint.fixable = ["ALL"]
+lint.pydocstyle.convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,12 @@ urls.Repository = "https://github.com/koek67/resume-builder"
 [dependency-groups]
 dev = ["mypy>=1.4.1", "ruff>=0.12.1"]
 
+[tool.hatch.build]
+dev-mode-dirs = ["."]
+only-include = ["LICENCE.txt", "README.md", "pyproject.toml", "src"]
 
 [tool.hatch.build.targets.wheel]
+include = ["src/py.typed"]
 packages = ["src"]
 
 [tool.hatch.build.targets.wheel.sources]

--- a/src/py.typed
+++ b/src/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The pathspec package uses inline types.


### PR DESCRIPTION
This PR adds `py.typed` marker file, following [PEP 561](https://peps.python.org/pep-0561/).
Additionally build config was updated to only include needed files & ignore the rest.

Updated install commands as well since this package is unpublished.